### PR TITLE
UI blurriness fix and Statustimers de-conflicting

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -25,7 +25,7 @@ require('common');
 local module = {};
 
 local INFINITE_DURATION = 0x7FFFFFFF
-REALUTCSTAMP_ID = 'statustimers:realutcstamp'
+REALUTCSTAMP_ID = addon.name .. ':realutcstamp'
 
 
 -- convert a u32 AARRGGBB color into an ImVec4

--- a/timer_group.lua
+++ b/timer_group.lua
@@ -224,8 +224,8 @@ function TimerGroup:move_to(x, y)
 
     for i = 0, 31 do
         self.timers[i+1].position_x = self.bg.position_x + self.settings.padding[1]
-        self.timers[i+1].position_y = self.bg.position_y + self.settings.padding[2] +
-            ((self.timers[i+1]:get_height() + self.settings.padding[4]) * i)
+        self.timers[i+1].position_y = math.floor(self.bg.position_y + self.settings.padding[2] +
+            ((self.timers[i+1]:get_height() + self.settings.padding[4]) * i))
     end
 end
 


### PR DESCRIPTION
Floor Y position of the timers so the text doesn't blur after the first timer, see pic
![image](https://user-images.githubusercontent.com/60417494/219262447-a9b638cf-15af-4c8f-abef-6561683e29f3.png)


The pointer used in `REALUTCSTAMP_ID` was a copypaste from Statustimers and this can conflict. This PR changes `REALUTCSTAMP_ID ` to include `addon.name` (and hopefully prevent future copy pastes from conflicting on the pointer). This does not effect functionality in any way.